### PR TITLE
test(generator): add TempModule helper to stabilize temp module creat…

### DIFF
--- a/internal/generator/admin_smoke_test.go
+++ b/internal/generator/admin_smoke_test.go
@@ -19,16 +19,7 @@ func TestCLI_GenerateAdmin_Smoke(t *testing.T) {
 		t.Fatalf("read module name: %v", err)
 	}
 
-	tmpProj := t.TempDir()
-	uid := filepath.Base(tmpProj)
-	// Use an independent module name (not a subpath of the repo module) to
-	// avoid Go module resolution treating the generated package as part of the
-	// main repo module. This prevents `go mod tidy` from attempting to fetch
-	// packages from the parent module.
-	moduleName := modName + "/examples/" + uid
-	if err := WriteTempGoMod(tmpProj, moduleName, true); err != nil {
-		t.Fatalf("write go.mod: %v", err)
-	}
+	tmpProj, moduleName := TempModule(t)
 
 	// build CLI binary
 	bin := filepath.Join(tmpProj, "flow-cli")

--- a/internal/generator/auth_generator_test.go
+++ b/internal/generator/auth_generator_test.go
@@ -73,14 +73,7 @@ func TestCLI_GenerateAuth_Compiles(t *testing.T) {
 		t.Fatalf("read module name: %v", err)
 	}
 
-	tmpProj := t.TempDir()
-	uid := filepath.Base(tmpProj)
-	moduleName := modName + "/examples/" + uid
-	// write a go.mod and add replace directive so the temp module can
-	// resolve the local repository packages.
-	if err := WriteTempGoMod(tmpProj, moduleName, false); err != nil {
-		t.Fatalf("write go.mod: %v", err)
-	}
+	tmpProj, moduleName := TempModule(t)
 
 	// build CLI
 	bin := filepath.Join(tmpProj, "flow-cli")

--- a/internal/generator/gen_compile_test.go
+++ b/internal/generator/gen_compile_test.go
@@ -15,12 +15,7 @@ func TestGeneratedModelCompilesAndRuns(t *testing.T) {
 		t.Fatalf("read module name: %v", err)
 	}
 	// create an isolated temporary module so tests don't modify repo/examples
-	projDir := t.TempDir()
-	uid := filepath.Base(projDir)
-	moduleName := modName + "/examples/" + uid
-	if err := WriteTempGoMod(projDir, moduleName, false); err != nil {
-		t.Fatalf("write go.mod: %v", err)
-	}
+	projDir, moduleName := TempModule(t)
 
 	// build CLI (binary written into the temp project)
 	bin := filepath.Join(projDir, "flow-cli")

--- a/internal/generator/testutil.go
+++ b/internal/generator/testutil.go
@@ -10,6 +10,31 @@ import (
 	"testing"
 )
 
+// TempModule creates a temporary Go module for generator tests. It creates a
+// temp directory via t.TempDir(), writes a go.mod that pins the repo module
+// via an absolute replace, and returns the project directory and the
+// generated module name. It also logs key `go env` values to help debug
+// toolchain issues in CI.
+func TempModule(t *testing.T) (projDir, moduleName string) {
+	t.Helper()
+	proj := t.TempDir()
+	uid := filepath.Base(proj)
+	repo := findRepoRoot()
+	modName, err := readModuleName(repo)
+	if err != nil {
+		t.Fatalf("read module name: %v", err)
+	}
+	moduleName = modName + "/examples/" + uid
+	if err := WriteTempGoMod(proj, moduleName, false); err != nil {
+		t.Fatalf("WriteTempGoMod failed: %v", err)
+	}
+	// Log relevant go env values to aid CI debugging when tests fail.
+	if out, err := exec.Command("go", "env", "GOMODCACHE", "GOPROXY", "GOSUMDB").CombinedOutput(); err == nil {
+		t.Logf("go env: %s", string(out))
+	}
+	return proj, moduleName
+}
+
 // findRepoRoot walks up from the current working directory until it finds a go.mod
 // and returns the directory path. If none is found it returns the original cwd.
 func findRepoRoot() string {

--- a/internal/generator/testutil_test.go
+++ b/internal/generator/testutil_test.go
@@ -14,13 +14,7 @@ func TestWriteTempGoMod_WritesGoVersionAndAbsoluteReplace(t *testing.T) {
 		t.Fatalf("read module name: %v", err)
 	}
 
-	proj := t.TempDir()
-	uid := filepath.Base(proj)
-	moduleName := modName + "/examples/" + uid
-
-	if err := WriteTempGoMod(proj, moduleName, false); err != nil {
-		t.Fatalf("WriteTempGoMod failed: %v", err)
-	}
+	proj, _ := TempModule(t)
 
 	b, err := os.ReadFile(filepath.Join(proj, "go.mod"))
 	if err != nil {


### PR DESCRIPTION
…ion and update tests to use it

<!--
Thank you for your pull request! Please provide a short description of the
change and reference any related issues.
-->

## Summary

Adds TempModule(t *testing.T) in [testutil.go](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to centralize temporary module creation for generator tests.
TempModule writes a minimal [go.mod](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with an absolute replace to the local repo and logs [go env](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values (GOMODCACHE/GOPROXY/GOSUMDB) to help debug CI failures.
Updated generator tests to use TempModule: [gen_compile_test.go](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [admin_smoke_test.go](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [auth_generator_test.go](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [testutil_test.go](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Notes that CI may need pinning of Go versions or explicit GOPROXY/GOSUMDB settings as a follow-up.

## Changes

- What changed
- Any new public APIs

## Checklist

- [ ] Tests added/updated
- [ ] gofmt applied
- [ ] go vet/staticcheck clean

## Related

Fixes: #
