### PR TITLE
ci: make coverage artifact globally unique (include github.run_id)

### DIFF
--- a/.github/workflows/ci-improved.yml
+++ b/.github/workflows/ci-improved.yml
@@ -103,9 +103,8 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          # Make artifact name unique per matrix job to avoid 409 Conflict when
-          # multiple matrix jobs upload the same artifact name in a single run.
-          name: coverage-report-${{ matrix.go-version }}
+          # Make artifact name unique per matrix job and per workflow run to avoid 409 Conflict
+          name: coverage-report-${{ matrix.go-version }}-${{ github.run_id }}
           path: .ci/coverage.out
 
       - name: Upload coverage to Codecov (guarded)


### PR DESCRIPTION
<!--
Thank you for your pull request! Please provide a short description of the
change and reference any related issues.
-->

## Summary

Describe the change and why it is needed.

## Changes

- What changed
- Any new public APIs

## Checklist

- [ ] Tests added/updated
- [ ] gofmt applied
- [ ] go vet/staticcheck clean

## Related

Fixes: #
