### PR TITLE
fix: add SlogLogger adapter bridging log/slog to the Logger interface

### DIFF
--- a/pkg/flow/logger_slog.go
+++ b/pkg/flow/logger_slog.go
@@ -1,0 +1,112 @@
+package flow
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// SlogLogger is an adapter that satisfies the framework's Logger interface
+// (Printf) and StructuredLogger interface using a *slog.Logger as the
+// backend. It bridges the older Printf-based contract with the structured
+// log/slog package introduced in Go 1.21.
+//
+// Usage:
+//
+// app := flow.New("myapp",
+//
+//	flow.WithLogger(flow.NewSlogLogger(slog.Default())),
+//
+// )
+//
+// Log levels:
+//   - Printf  → slog.Info   (matches existing StdLogger behaviour)
+//   - Info    → slog.Info
+//   - Debug   → slog.Debug
+//   - Warn    → slog.Warn
+//   - Error   → slog.Error
+type SlogLogger struct {
+	l *slog.Logger
+}
+
+// NewSlogLogger returns a Logger (and StructuredLogger) backed by the given
+// *slog.Logger. If l is nil, slog.Default() is used so callers can write:
+//
+// flow.WithLogger(flow.NewSlogLogger(nil))
+func NewSlogLogger(l *slog.Logger) *SlogLogger {
+	if l == nil {
+		l = slog.Default()
+	}
+	return &SlogLogger{l: l}
+}
+
+// Printf implements Logger. The format string is expanded with fmt.Sprintf
+// and emitted at slog.LevelInfo, matching the behaviour of StdLogger.Printf.
+func (s *SlogLogger) Printf(format string, v ...interface{}) {
+	s.l.Info(fmt.Sprintf(format, v...))
+}
+
+// Debug implements StructuredLogger.
+func (s *SlogLogger) Debug(ctx context.Context, msg string, keyvals ...interface{}) {
+	s.l.DebugContext(ctx, msg, keyvals...)
+}
+
+// Info implements StructuredLogger.
+func (s *SlogLogger) Info(ctx context.Context, msg string, keyvals ...interface{}) {
+	s.l.InfoContext(ctx, msg, keyvals...)
+}
+
+// Warn implements StructuredLogger.
+func (s *SlogLogger) Warn(ctx context.Context, msg string, keyvals ...interface{}) {
+	s.l.WarnContext(ctx, msg, keyvals...)
+}
+
+// Error implements StructuredLogger.
+func (s *SlogLogger) Error(ctx context.Context, msg string, keyvals ...interface{}) {
+	s.l.ErrorContext(ctx, msg, keyvals...)
+}
+
+// Log implements StructuredLogger. The level string is mapped to the
+// corresponding slog.Level; unknown values fall back to slog.LevelInfo.
+// Fields are passed as slog key-value pairs after redaction.
+func (s *SlogLogger) Log(level string, msg string, fields map[string]interface{}) {
+	sl := slogLevel(level)
+	if !s.l.Enabled(context.Background(), sl) {
+		return
+	}
+	args := fieldsToSlogArgs(RedactMap(fields))
+	s.l.Log(context.Background(), sl, msg, args...)
+}
+
+// Slog returns the underlying *slog.Logger so callers can use slog-specific
+// features (e.g. WithGroup, WithAttrs) after obtaining an SlogLogger.
+func (s *SlogLogger) Slog() *slog.Logger {
+	return s.l
+}
+
+// slogLevel maps a StructuredLogger level string to a slog.Level.
+func slogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// fieldsToSlogArgs converts a map[string]interface{} into a flat slice of
+// alternating key/value arguments compatible with slog's variadic API.
+func fieldsToSlogArgs(fields map[string]interface{}) []interface{} {
+	if len(fields) == 0 {
+		return nil
+	}
+	args := make([]interface{}, 0, len(fields)*2)
+	for k, v := range fields {
+		args = append(args, k, v)
+	}
+	return args
+}

--- a/pkg/flow/logger_slog_test.go
+++ b/pkg/flow/logger_slog_test.go
@@ -1,0 +1,196 @@
+package flow
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestSlogLogger returns a *SlogLogger that writes JSON lines to buf.
+func newTestSlogLogger(buf *bytes.Buffer) *SlogLogger {
+	h := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return NewSlogLogger(slog.New(h))
+}
+
+// ── interface compliance ──────────────────────────────────────────────────────
+
+// TestSlogLogger_ImplementsLogger verifies *SlogLogger satisfies Logger.
+func TestSlogLogger_ImplementsLogger(t *testing.T) {
+	var _ Logger = NewSlogLogger(nil)
+}
+
+// TestSlogLogger_ImplementsStructuredLogger verifies *SlogLogger satisfies StructuredLogger.
+func TestSlogLogger_ImplementsStructuredLogger(t *testing.T) {
+	var _ StructuredLogger = NewSlogLogger(nil)
+}
+
+// ── NewSlogLogger ─────────────────────────────────────────────────────────────
+
+// TestNewSlogLogger_NilUsesDefault verifies that passing nil uses slog.Default()
+// without panicking.
+func TestNewSlogLogger_NilUsesDefault(t *testing.T) {
+	sl := NewSlogLogger(nil)
+	if sl == nil {
+		t.Fatal("expected non-nil SlogLogger")
+	}
+	if sl.Slog() == nil {
+		t.Fatal("expected non-nil underlying *slog.Logger")
+	}
+}
+
+// TestNewSlogLogger_CustomLogger verifies the provided *slog.Logger is stored.
+func TestNewSlogLogger_CustomLogger(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, nil)
+	base := slog.New(h)
+	sl := NewSlogLogger(base)
+	if sl.Slog() != base {
+		t.Fatal("Slog() did not return the provided logger")
+	}
+}
+
+// ── Printf ────────────────────────────────────────────────────────────────────
+
+// TestSlogLogger_Printf_EmitsAtInfo verifies Printf output appears at level INFO.
+func TestSlogLogger_Printf_EmitsAtInfo(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Printf("hello %s", "world")
+	out := buf.String()
+	if !strings.Contains(out, "hello world") {
+		t.Fatalf("Printf: message not found in output: %s", out)
+	}
+	if !strings.Contains(out, `"level":"INFO"`) {
+		t.Fatalf("Printf: expected INFO level, got: %s", out)
+	}
+}
+
+// TestSlogLogger_Printf_Formatting verifies fmt-style formatting works.
+func TestSlogLogger_Printf_Formatting(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Printf("count=%d ratio=%.2f", 42, 3.14)
+	out := buf.String()
+	if !strings.Contains(out, "count=42 ratio=3.14") {
+		t.Fatalf("Printf format mismatch: %s", out)
+	}
+}
+
+// ── StructuredLogger methods ──────────────────────────────────────────────────
+
+func TestSlogLogger_Debug(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Debug(context.Background(), "debug-msg", "k", "v")
+	out := buf.String()
+	if !strings.Contains(out, "debug-msg") {
+		t.Fatalf("Debug: message not found: %s", out)
+	}
+	if !strings.Contains(out, `"level":"DEBUG"`) {
+		t.Fatalf("Debug: expected DEBUG level: %s", out)
+	}
+}
+
+func TestSlogLogger_Info(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Info(context.Background(), "info-msg")
+	out := buf.String()
+	if !strings.Contains(out, "info-msg") || !strings.Contains(out, `"level":"INFO"`) {
+		t.Fatalf("Info: unexpected output: %s", out)
+	}
+}
+
+func TestSlogLogger_Warn(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Warn(context.Background(), "warn-msg")
+	out := buf.String()
+	if !strings.Contains(out, "warn-msg") || !strings.Contains(out, `"level":"WARN"`) {
+		t.Fatalf("Warn: unexpected output: %s", out)
+	}
+}
+
+func TestSlogLogger_Error(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Error(context.Background(), "error-msg")
+	out := buf.String()
+	if !strings.Contains(out, "error-msg") || !strings.Contains(out, `"level":"ERROR"`) {
+		t.Fatalf("Error: unexpected output: %s", out)
+	}
+}
+
+// ── Log (level string mapping) ────────────────────────────────────────────────
+
+func TestSlogLogger_Log_LevelMapping(t *testing.T) {
+	cases := []struct {
+		level    string
+		wantSlog string
+	}{
+		{"debug", `"level":"DEBUG"`},
+		{"info", `"level":"INFO"`},
+		{"warn", `"level":"WARN"`},
+		{"warning", `"level":"WARN"`},
+		{"error", `"level":"ERROR"`},
+		{"unknown", `"level":"INFO"`}, // fallback
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.level, func(t *testing.T) {
+			var buf bytes.Buffer
+			sl := newTestSlogLogger(&buf)
+			sl.Log(tc.level, "msg", nil)
+			out := buf.String()
+			if !strings.Contains(out, tc.wantSlog) {
+				t.Fatalf("level=%q: expected %q in output: %s", tc.level, tc.wantSlog, out)
+			}
+		})
+	}
+}
+
+// TestSlogLogger_Log_FieldsRedacted verifies that secret fields are redacted
+// before being forwarded to slog.
+func TestSlogLogger_Log_FieldsRedacted(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	sl.Log("info", "user action", map[string]interface{}{
+		"password": "super-secret",
+		"user":     "alice",
+	})
+	out := buf.String()
+	if strings.Contains(out, "super-secret") {
+		t.Fatalf("secret password should be redacted, got: %s", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] marker in output: %s", out)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Fatalf("non-secret field 'user' should be present: %s", out)
+	}
+}
+
+// ── WithLogger integration ────────────────────────────────────────────────────
+
+// TestSlogLogger_WithLogger_Integration verifies that an App wired with
+// WithLogger(NewSlogLogger(...)) routes its internal Printf calls through slog.
+func TestSlogLogger_WithLogger_Integration(t *testing.T) {
+	var buf bytes.Buffer
+	sl := newTestSlogLogger(&buf)
+	a := New("slog-app", WithLogger(sl))
+	a.Addr = ":0"
+	if err := a.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = a.Shutdown(ctx)
+	// Shutdown logs "shutting down <name>" — verify it went through slog.
+	out := buf.String()
+	if !strings.Contains(out, "slog-app") {
+		t.Fatalf("expected app name in slog output during shutdown, got: %s", out)
+	}
+}


### PR DESCRIPTION
Projects using Go's standard log/slog package had to write their own adapter to satisfy flow's Logger/StructuredLogger interfaces. This added boilerplate and was a barrier to adoption of the framework.

Changes:
- pkg/flow/logger_slog.go (new) · SlogLogger struct wrapping *slog.Logger · NewSlogLogger(l *slog.Logger) — nil falls back to slog.Default() · Printf(format, v...)  → slog.Info  (Logger interface) · Debug/Info/Warn/Error — StructuredLogger interface via *Context methods · Log(level, msg, fields) — level string mapped to slog.Level; unknown levels fall back to INFO; fields are redacted via RedactMap before forwarding to slog to preserve secure-by-default behaviour · Slog() *slog.Logger accessor for slog-specific features · slogLevel() and fieldsToSlogArgs() private helpers
- pkg/flow/logger_slog_test.go (new) · 15 tests: interface compliance, nil constructor, Printf formatting, all 4 StructuredLogger methods, all level mappings incl. fallback, redaction of secret fields, end-to-end WithLogger integration

<!--
Provide a short description of the change and reference any related issues.
Title format: feat(pkg): short description
-->

## Summary

Describe the change and why it's needed.

## Checklist
- [ ] Tests added/updated
- [ ] gofmt run (no changes required)
- [ ] go vet and staticcheck run locally
- [ ] Documentation updated (where applicable)

## Related
- Fixes: #

---
Please follow the repository CONTRIBUTING.md and add reviewer suggestions where appropriate.
