### PR TITLE
fix: flow new scaffolds test files alongside application code

### DIFF
--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -97,12 +97,13 @@ layout ready for development.
 
 The generated structure includes:
   <app-name>/
-    cmd/<app-name>/main.go   – application entry-point
-    internal/                – private application packages
-    db/migrations/           – SQL migration files
-    go.mod                   – module definition
-    .env.example             – documented environment variables
-    Makefile                 – common developer tasks`,
+    cmd/<app-name>/main.go          – application entry-point
+    cmd/<app-name>/main_test.go     – smoke test for the entry-point package
+    internal/<app-name>_test.go     – placeholder integration test
+    db/migrations/                  – SQL migration files
+    go.mod                          – module definition
+    .env.example                    – documented environment variables
+    Makefile                        – common developer tasks (includes 'make test')`,
 	Args: cobra.ExactArgs(1),
 	RunE: runNew,
 }
@@ -146,6 +147,34 @@ func main() {
 	if err := app.Run(); err != nil {
 		log.Fatal(err)
 	}
+}
+`, name),
+
+		filepath.Join(root, "cmd", name, "main_test.go"): fmt.Sprintf(`package main
+
+import (
+	"testing"
+)
+
+// TestSmoke verifies the application entry-point package compiles and the
+// test harness is wired up correctly. Replace this with meaningful tests
+// as your application grows.
+func TestSmoke(t *testing.T) {
+	t.Logf("%s: smoke test passed – add real tests here")
+}
+`, name),
+
+		filepath.Join(root, "internal", name+"_test.go"): fmt.Sprintf(`package internal_test
+
+import (
+	"testing"
+)
+
+// TestIntegration is a placeholder for %s integration tests.
+// Wire up your app, make HTTP requests against a test server, and assert
+// the responses here.
+func TestIntegration(t *testing.T) {
+	t.Skip("replace with real integration tests")
 }
 `, name),
 

--- a/cmd/flow/new_cmd_test.go
+++ b/cmd/flow/new_cmd_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// scaffoldApp calls runNew via the cobra command tree into a temporary
+// directory and returns the project root path.
+func scaffoldApp(t *testing.T, name string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	root := &cobra.Command{Use: "flow"}
+	root.AddCommand(newCmd)
+	root.SetArgs([]string{"new", name})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("flow new %s: %v", name, err)
+	}
+	return filepath.Join(tmp, name)
+}
+
+func TestRunNew_CreatesMainTestFile(t *testing.T) {
+	root := scaffoldApp(t, "myapp")
+	path := filepath.Join(root, "cmd", "myapp", "main_test.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("main_test.go not created: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "package main") {
+		t.Error("main_test.go: expected 'package main'")
+	}
+	if !strings.Contains(content, "func TestSmoke") {
+		t.Error("main_test.go: expected 'func TestSmoke'")
+	}
+}
+
+func TestRunNew_CreatesInternalTestFile(t *testing.T) {
+	root := scaffoldApp(t, "myapp2")
+	path := filepath.Join(root, "internal", "myapp2_test.go")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("internal/<app>_test.go not created: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "package internal_test") {
+		t.Error("internal test file: expected 'package internal_test'")
+	}
+	if !strings.Contains(content, "func TestIntegration") {
+		t.Error("internal test file: expected 'func TestIntegration'")
+	}
+}
+
+func TestRunNew_TestFileContainsAppName(t *testing.T) {
+	const appName = "coolapp"
+	root := scaffoldApp(t, appName)
+
+	smokeData, err := os.ReadFile(filepath.Join(root, "cmd", appName, "main_test.go"))
+	if err != nil {
+		t.Fatalf("main_test.go not created: %v", err)
+	}
+	if !strings.Contains(string(smokeData), appName) {
+		t.Errorf("main_test.go: expected app name %q in content", appName)
+	}
+
+	intData, err := os.ReadFile(filepath.Join(root, "internal", appName+"_test.go"))
+	if err != nil {
+		t.Fatalf("internal test file not created: %v", err)
+	}
+	if !strings.Contains(string(intData), appName) {
+		t.Errorf("internal test file: expected app name %q in content", appName)
+	}
+}
+
+func TestRunNew_AllExpectedFilesExist(t *testing.T) {
+	root := scaffoldApp(t, "fullapp")
+	expected := []string{
+		"go.mod",
+		filepath.Join("cmd", "fullapp", "main.go"),
+		filepath.Join("cmd", "fullapp", "main_test.go"),
+		filepath.Join("internal", "fullapp_test.go"),
+		".env.example",
+		"Makefile",
+	}
+	for _, rel := range expected {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Errorf("expected file missing: %s", rel)
+		}
+	}
+}
+
+func TestRunNew_RejectsExistingDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	_ = os.Chdir(tmp)
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	// pre-create the directory
+	if err := os.Mkdir("taken", 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	root := &cobra.Command{Use: "flow"}
+	root.AddCommand(newCmd)
+	root.SetArgs([]string{"new", "taken"})
+	if err := root.Execute(); err == nil {
+		t.Error("expected error when target directory already exists, got nil")
+	}
+}


### PR DESCRIPTION
Add cmd/<app>/main_test.go (smoke test) and internal/<app>_test.go (integration placeholder) to the files emitted by 'flow new'.

Previously the generated project had a 'make test' target that ran 'go test ./...' but contained zero test files, giving new developers no baseline and no example of how to test a Flow application.

- cmd/<app>/main_test.go   – TestSmoke in package main; verifies the
                             entry-point package compiles under test
- internal/<app>_test.go   – TestIntegration in package internal_test;
                             skipped placeholder showing the pattern for
                             HTTP integration tests
- Update newCmd.Long description to list the generated test files
- Add new_cmd_test.go: 5 table-style tests covering all generated files,
  app-name interpolation, and directory-exists guard

<!--
Provide a short description of the change and reference any related issues.
Title format: feat(pkg): short description
-->

## Summary

Describe the change and why it's needed.

## Checklist
- [ ] Tests added/updated
- [ ] gofmt run (no changes required)
- [ ] go vet and staticcheck run locally
- [ ] Documentation updated (where applicable)

## Related
- Fixes: #

---
Please follow the repository CONTRIBUTING.md and add reviewer suggestions where appropriate.
