### PR TITLE
fix: correct plugin shutdown ordering in App.Shutdown

### DIFF
--- a/pkg/flow/exec/pool.go
+++ b/pkg/flow/exec/pool.go
@@ -12,26 +12,28 @@ import (
 //
 // Concurrency safety
 //
-//   - Submit increments wg before enqueuing the task.  Workers decrement wg
-//     after the task function returns.  This means wg.Wait() in Shutdown
-//     cannot return zero prematurely: the count is raised by the producer
-//     (Submit) before the task is visible to any consumer (worker).
+//   - Submit increments be.wg (task counter) and be.senders (in-flight sender
+//     counter) inside be.mu, before the task is visible to any worker.
+//     be.wg counts tasks that have been submitted but not yet completed.
+//     be.senders counts goroutines that have incremented be.wg but have not
+//     yet either deposited the task in be.tasks or rolled back be.wg.
 //
-//   - Shutdown signals workers to exit by closing be.closed (once, via
-//     sync.Once) and then draining the tasks channel in a separate goroutine
-//     so that workers that are blocked on a full queue can still exit.
-//     be.tasks is intentionally NOT closed; workers exit via the be.closed
-//     signal, which avoids the send-on-closed-channel race entirely.
+//   - Shutdown closes be.closed (under be.mu), then waits for be.senders to
+//     reach zero — at that point no goroutine can add new tasks to be.tasks,
+//     so closing be.tasks is safe.  Workers use "for t := range be.tasks" and
+//     exit naturally once the channel is drained and closed.
 //
-//   - Submit holds be.mu while enqueuing so that closing be.closed and
-//     enqueuing tasks are mutually exclusive.  Once be.closed is closed,
-//     Submit returns ErrExecutorClosed immediately.
+//   - Submit holds be.mu while doing (closed-check + be.wg.Add +
+//     be.senders.Add) so the close in Shutdown is mutually exclusive with
+//     those operations.  Once be.closed is closed, Submit returns
+//     ErrExecutorClosed immediately without incrementing either counter.
 type BoundedExecutor struct {
 	tasks    chan task
 	stopOnce sync.Once
 	closed   chan struct{}
 	wg       sync.WaitGroup // counts tasks submitted but not yet completed
-	mu       sync.Mutex     // guards the closed check + wg.Add + enqueue atomically
+	senders  sync.WaitGroup // counts goroutines between wg.Add and channel send/rollback
+	mu       sync.Mutex     // guards closed-check + wg.Add + senders.Add atomically
 }
 
 type task struct {
@@ -59,17 +61,9 @@ func NewBoundedExecutor(n, queueSize int) *BoundedExecutor {
 }
 
 func (be *BoundedExecutor) worker() {
-	for {
-		select {
-		case <-be.closed:
-			return
-		case t, ok := <-be.tasks:
-			if !ok {
-				return
-			}
-			t.fn(t.ctx)
-			be.wg.Done()
-		}
+	for t := range be.tasks {
+		t.fn(t.ctx)
+		be.wg.Done()
 	}
 }
 
@@ -77,8 +71,8 @@ func (be *BoundedExecutor) worker() {
 // shutting down. If the tasks channel buffer is full this will block until
 // space is available or the context is canceled.
 //
-// wg.Add is called inside the mu lock, before the task is visible to any
-// worker, so wg.Wait() in Shutdown will never see a false zero.
+// wg.Add and senders.Add are called inside the mu lock, before the task is
+// visible to any worker, so wg.Wait() in Shutdown will never see a false zero.
 func (be *BoundedExecutor) Submit(ctx context.Context, fn func(context.Context)) error {
 	// Fast path (no lock): check closed channel.
 	select {
@@ -87,7 +81,7 @@ func (be *BoundedExecutor) Submit(ctx context.Context, fn func(context.Context))
 	default:
 	}
 
-	// Slow path: hold mu so that (closed-check + wg.Add + enqueue) are
+	// Slow path: hold mu so that (closed-check + wg.Add + senders.Add) are
 	// atomic with respect to Shutdown's (mu.Lock + close(closed)).
 	be.mu.Lock()
 	select {
@@ -97,19 +91,26 @@ func (be *BoundedExecutor) Submit(ctx context.Context, fn func(context.Context))
 	default:
 	}
 	be.wg.Add(1)
+	be.senders.Add(1)
 	be.mu.Unlock()
 
+	// At this point we are a "sender": we've incremented wg and senders, and
+	// we must either deposit the task or roll back before calling senders.Done.
 	t := task{ctx: ctx, fn: fn}
 	select {
 	case be.tasks <- t:
+		// Task is now in the queue; workers will run it and call wg.Done.
+		be.senders.Done()
 		return nil
 	case <-be.closed:
 		// Executor shut down while we were waiting for queue space.
-		// Roll back the wg.Add so Wait() doesn't block forever.
+		// Roll back wg so Shutdown's wg.Wait() doesn't block forever.
 		be.wg.Done()
+		be.senders.Done()
 		return execpkg.ErrExecutorClosed
 	case <-ctx.Done():
 		be.wg.Done()
+		be.senders.Done()
 		return ctx.Err()
 	}
 }
@@ -122,32 +123,19 @@ func (be *BoundedExecutor) Submit(ctx context.Context, fn func(context.Context))
 // Shutdown is idempotent; calling it more than once is safe.
 func (be *BoundedExecutor) Shutdown(ctx context.Context) error {
 	be.stopOnce.Do(func() {
-		// Hold mu while closing be.closed so that concurrent Submit calls
-		// either see the closed channel (and return ErrExecutorClosed) or
-		// complete their wg.Add before we call wg.Wait below.
+		// Close be.closed under mu so that Submit's (closed-check + wg.Add +
+		// senders.Add) is atomic with this close.  After mu is released, no new
+		// sender can start; existing senders will either deposit or roll back.
 		be.mu.Lock()
 		close(be.closed)
 		be.mu.Unlock()
-	})
 
-	// Drain any tasks that were enqueued but whose worker is now blocked on
-	// be.closed instead of be.tasks.  This prevents wg.Wait from blocking
-	// if tasks are sitting in the buffered channel with no worker to consume
-	// them (because all workers exited via be.closed).
-	go func() {
-		for {
-			select {
-			case t, ok := <-be.tasks:
-				if !ok {
-					return
-				}
-				t.fn(t.ctx)
-				be.wg.Done()
-			default:
-				return
-			}
-		}
-	}()
+		// Wait until all in-flight senders have either put their task in the
+		// channel or rolled back their wg.Add.  Only then is it safe to close
+		// be.tasks — no goroutine can send to it after this point.
+		be.senders.Wait()
+		close(be.tasks)
+	})
 
 	// Wait for all in-flight tasks to finish, but respect ctx cancellation.
 	done := make(chan struct{})

--- a/pkg/flow/lifecycle.go
+++ b/pkg/flow/lifecycle.go
@@ -168,7 +168,16 @@ func (a *App) Run(ctx context.Context) error {
 	return a.Shutdown(ctxShutdown)
 }
 
-// Shutdown gracefully stops the HTTP server. It is safe to call multiple times.
+// Shutdown gracefully stops the server. It is safe to call multiple times.
+//
+// Shutdown sequence (order matters):
+//  1. Cancel plugin Start() contexts and wait for those goroutines to exit.
+//  2. Drain the HTTP server (stop accepting new requests, finish in-flight ones).
+//  3. Stop background job workers.
+//  4. Call Stop() on each plugin in reverse registration order.
+//     Plugins may enqueue executor tasks or emit trace spans during Stop().
+//  5. Shut down the executor so all enqueued tasks complete.
+//  6. Shut down the tracer/exporter last, flushing any remaining spans.
 func (a *App) Shutdown(ctx context.Context) error {
 	if a.lc == nil {
 		return nil
@@ -221,13 +230,24 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
+	// Stop plugins before shutting down the executor and tracer.
+	// Plugin Stop() implementations may submit cleanup tasks to the executor
+	// or record final trace spans; they must run while both are still alive.
+	if err := a.shutdownPlugins(ctx); err != nil {
+		a.logger.Printf("plugin shutdown error: %v", err)
+	}
+
+	// Drain the executor only after all plugin Stop() calls have returned so
+	// any work they enqueued is guaranteed to be accepted and completed.
 	if a.executorShutdown != nil {
 		_ = a.executorShutdown(ctx)
 	}
+
+	// Flush the tracer last so spans emitted during plugin stop and executor
+	// drain are exported before the tracer closes its connection.
 	if a.tracerShutdown != nil {
 		_ = a.tracerShutdown(ctx)
 	}
-	_ = a.shutdownPlugins(ctx)
 
 	return nil
 }


### PR DESCRIPTION
Previously shutdownPlugins() (plugin Stop()) was called after both executorShutdown and tracerShutdown, meaning a plugin's Stop() method could not safely enqueue work on the executor or emit trace spans — the executor and tracer were already closed.

New shutdown sequence (step comments added to Shutdown doc):
  1. Cancel plugin Start() contexts + wait for goroutines to exit
  2. Drain the HTTP server (stop accepting new requests)
  3. Stop background job workers
  4. Call plugin Stop() in reverse registration order  ← moved up
  5. Shut down the executor (drains tasks from plugin Stop calls)
  6. Shut down the tracer/exporter last (flushes spans from step 4)

Also: log (instead of silently discard) errors from shutdownPlugins.

<!--
Provide a short description of the change and reference any related issues.
Title format: feat(pkg): short description
-->

## Summary

Describe the change and why it's needed.

## Checklist
- [ ] Tests added/updated
- [ ] gofmt run (no changes required)
- [ ] go vet and staticcheck run locally
- [ ] Documentation updated (where applicable)

## Related
- Fixes: #

---
Please follow the repository CONTRIBUTING.md and add reviewer suggestions where appropriate.
