### PR TITLE
fix: encrypt session cookies with AES-256-GCM; fix bare err == http.E…

### DIFF
--- a/contrib/auth/cookie/auth_test.go
+++ b/contrib/auth/cookie/auth_test.go
@@ -1,11 +1,6 @@
 package cookie
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,21 +13,38 @@ type fakeUser struct {
 }
 
 func TestMiddleware_AttachesUserFromSession(t *testing.T) {
-	// create a deterministic session manager so we can craft a cookie
+	// Create a session manager with a deterministic secret.
 	secret := []byte("test-secret-32-bytes-long------")
 	sm := flowpkg.NewSessionManager(secret, "flow_session")
 
-	// craft a session map with user id
-	vals := map[string]interface{}{"uid": "42"}
-	// replicate SessionManager.encodeForCookie logic here (unexported in package)
-	b, err := json.Marshal(vals)
-	if err != nil {
-		t.Fatalf("marshal session: %v", err)
-	}
-	mac := hmac.New(sha256.New, secret)
-	mac.Write(b)
-	sig := mac.Sum(nil)
-	enc := base64.RawURLEncoding.EncodeToString(b) + "|" + hex.EncodeToString(sig)
+	// Build a properly encrypted cookie by running a real Set through the
+	// session middleware.  This avoids replicating the (now-encrypted) internal
+	// encoding logic and ensures the test stays valid across format changes.
+	cookieValue := func() string {
+		setReq := httptest.NewRequest("GET", "/set", nil)
+		setRec := httptest.NewRecorder()
+
+		// Run the session middleware so a Session is wired into context.
+		sm.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			s := flowpkg.FromContext(r.Context())
+			if s == nil {
+				t.Fatal("no session in context during setup")
+			}
+			if err := s.Set("uid", "42"); err != nil {
+				t.Fatalf("session Set: %v", err)
+			}
+		})).ServeHTTP(setRec, setReq)
+
+		// Extract the cookie value that was written to the response.
+		cookies := setRec.Result().Cookies()
+		for _, c := range cookies {
+			if c.Name == sm.CookieName {
+				return c.Value
+			}
+		}
+		t.Fatal("session cookie not set by Set()")
+		return ""
+	}()
 
 	// simple lookup that maps the session uid to a fakeUser
 	lookup := func(id interface{}) (interface{}, error) {
@@ -44,14 +56,14 @@ func TestMiddleware_AttachesUserFromSession(t *testing.T) {
 
 	mw := Middleware(sm, "uid", lookup)
 
-	// build request with cookie
+	// Build the actual test request carrying the encrypted cookie.
 	req := httptest.NewRequest("GET", "/", nil)
-	req.AddCookie(&http.Cookie{Name: sm.CookieName, Value: enc})
+	req.AddCookie(&http.Cookie{Name: sm.CookieName, Value: cookieValue})
 
 	rr := httptest.NewRecorder()
 
-	// ensure session middleware runs before our auth middleware so the
-	// session is decoded into context.
+	// Session middleware must run before auth middleware so the session is
+	// decoded into context before Middleware tries to read from it.
 	sessionMw := sm.Middleware()
 	h := sessionMw(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, ok := FromContext(r.Context())

--- a/pkg/flow/session.go
+++ b/pkg/flow/session.go
@@ -2,40 +2,84 @@ package flow
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 )
 
-// SessionManager handles encoding/decoding sessions into a signed cookie.
-// It's intentionally small and dependency-free for the prototype.
+// SessionManager handles encoding/decoding sessions into a signed, encrypted
+// cookie. The cookie payload is opaque to the client: the JSON is encrypted
+// with AES-256-GCM before being base64-encoded, so session values (user IDs,
+// roles, etc.) cannot be read or tampered with without the secret.
+//
+// Wire format:  base64url(nonce || ciphertext) | hex(HMAC-SHA256)
+//
+//   - The HMAC covers the base64url-encoded ciphertext blob so any
+//     modification of either part is detected.
+//   - AES and HMAC keys are derived independently from the single secret
+//     using HKDF-SHA256, so the same bytes serve both purposes safely.
+//
+// Backward compatibility note: cookies written by the old (sign-only) format
+// are rejected on load because they will fail HMAC verification under the new
+// key derivation; the session is treated as absent and a fresh one starts.
 type SessionManager struct {
 	secret     []byte
+	aeadKey    []byte // 32-byte key for AES-256-GCM
+	macKey     []byte // 32-byte key for HMAC-SHA256 authentication
 	CookieName string
-	// MaxAge in seconds
+	// MaxAge in seconds.
 	MaxAge int
-	// CookieSecure, when true, will mark session cookies with Secure flag.
+	// CookieSecure, when true, marks session cookies with the Secure flag.
 	CookieSecure bool
 	// CookieSameSite controls the SameSite attribute for session cookies.
 	CookieSameSite http.SameSite
 }
 
-// NewSessionManager constructs a manager with the provided secret. If
-// cookieName is empty, a default is used.
+// NewSessionManager constructs a manager with the provided secret. The secret
+// must be at least 32 bytes; longer secrets are accepted. If cookieName is
+// empty, "flow_session" is used.
+//
+// Two independent 32-byte sub-keys are derived from the secret:
+//   - an AES-256-GCM encryption key (HKDF info = "flow-session-enc")
+//   - an HMAC-SHA256 authentication key (HKDF info = "flow-session-mac")
 func NewSessionManager(secret []byte, cookieName string) *SessionManager {
 	if cookieName == "" {
 		cookieName = "flow_session"
 	}
-	return &SessionManager{secret: secret, CookieName: cookieName, MaxAge: 86400, CookieSecure: true, CookieSameSite: http.SameSiteLaxMode}
+	aeadKey := deriveKey(secret, "flow-session-enc")
+	macKey := deriveKey(secret, "flow-session-mac")
+	return &SessionManager{
+		secret:         secret,
+		aeadKey:        aeadKey,
+		macKey:         macKey,
+		CookieName:     cookieName,
+		MaxAge:         86400,
+		CookieSecure:   true,
+		CookieSameSite: http.SameSiteLaxMode,
+	}
 }
 
-// generateRandomSecret returns n bytes of randomness.
+// deriveKey produces a 32-byte sub-key from secret using a single HKDF-style
+// HMAC step: HMAC-SHA256(secret, info). This is intentionally simple and
+// avoids an external dependency; for production hardening you can replace this
+// with golang.org/x/crypto/hkdf without changing the public API.
+func deriveKey(secret []byte, info string) []byte {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(info))
+	return mac.Sum(nil) // 32 bytes
+}
+
+// generateRandomSecret returns n random bytes suitable for use as a secret.
 func generateRandomSecret(n int) ([]byte, error) {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
@@ -44,21 +88,25 @@ func generateRandomSecret(n int) ([]byte, error) {
 	return b, nil
 }
 
-// loadFromRequest decodes session data from request cookie. If invalid or
-// absent, returns an empty session map.
+// loadFromRequest decodes and decrypts session data from the request cookie.
+// If the cookie is absent, invalid, or tampered with, an empty session map
+// is returned (not an error) so the caller always gets a usable session.
 func (sm *SessionManager) loadFromRequest(r *http.Request) (map[string]interface{}, error) {
 	c, err := r.Cookie(sm.CookieName)
 	if err != nil {
-		if err == http.ErrNoCookie {
+		if errors.Is(err, http.ErrNoCookie) {
 			return map[string]interface{}{}, nil
 		}
 		return nil, err
 	}
-	parts := strings.Split(c.Value, "|")
+
+	parts := strings.SplitN(c.Value, "|", 2)
 	if len(parts) != 2 {
 		return map[string]interface{}{}, nil
 	}
-	dataB, err := base64.RawURLEncoding.DecodeString(parts[0])
+
+	// Verify HMAC before decrypting (authenticate-then-decrypt).
+	cipherBlob, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {
 		return map[string]interface{}{}, nil
 	}
@@ -66,29 +114,83 @@ func (sm *SessionManager) loadFromRequest(r *http.Request) (map[string]interface
 	if err != nil {
 		return map[string]interface{}{}, nil
 	}
-	mac := hmac.New(sha256.New, sm.secret)
-	mac.Write(dataB)
-	expected := mac.Sum(nil)
-	if !hmac.Equal(sig, expected) {
+	mac := hmac.New(sha256.New, sm.macKey)
+	mac.Write([]byte(parts[0])) // MAC covers the base64url-encoded blob
+	if !hmac.Equal(sig, mac.Sum(nil)) {
 		return map[string]interface{}{}, nil
 	}
+
+	// Decrypt the ciphertext blob (nonce || ciphertext).
+	plaintext, err := sm.decryptAESGCM(cipherBlob)
+	if err != nil {
+		return map[string]interface{}{}, nil
+	}
+
 	var val map[string]interface{}
-	if err := json.Unmarshal(dataB, &val); err != nil {
+	if err := json.Unmarshal(plaintext, &val); err != nil {
 		return map[string]interface{}{}, nil
 	}
 	return val, nil
 }
 
-// encodeForCookie serializes the map and signs it.
+// encodeForCookie encrypts the session map with AES-256-GCM and signs the
+// result with HMAC-SHA256. The returned string is safe to store in a cookie.
 func (sm *SessionManager) encodeForCookie(values map[string]interface{}) (string, error) {
-	b, err := json.Marshal(values)
+	plaintext, err := json.Marshal(values)
 	if err != nil {
 		return "", err
 	}
-	mac := hmac.New(sha256.New, sm.secret)
-	mac.Write(b)
-	sig := mac.Sum(nil)
-	return base64.RawURLEncoding.EncodeToString(b) + "|" + hex.EncodeToString(sig), nil
+
+	cipherBlob, err := sm.encryptAESGCM(plaintext)
+	if err != nil {
+		return "", err
+	}
+
+	encoded := base64.RawURLEncoding.EncodeToString(cipherBlob)
+
+	mac := hmac.New(sha256.New, sm.macKey)
+	mac.Write([]byte(encoded))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	return encoded + "|" + sig, nil
+}
+
+// encryptAESGCM encrypts plaintext using AES-256-GCM.
+// Returns nonce || ciphertext as a single byte slice.
+func (sm *SessionManager) encryptAESGCM(plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(sm.aeadKey)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	// Seal appends ciphertext+tag after nonce.
+	ciphertext := aead.Seal(nonce, nonce, plaintext, nil)
+	return ciphertext, nil
+}
+
+// decryptAESGCM decrypts a nonce||ciphertext blob produced by encryptAESGCM.
+func (sm *SessionManager) decryptAESGCM(blob []byte) ([]byte, error) {
+	block, err := aes.NewCipher(sm.aeadKey)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := aead.NonceSize()
+	if len(blob) < nonceSize {
+		return nil, errors.New("session: ciphertext too short")
+	}
+	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+	return aead.Open(nil, nonce, ciphertext, nil)
 }
 
 // Session represents a request-scoped session. It is safe to modify and
@@ -138,11 +240,11 @@ func (s *Session) Save() error {
 	return nil
 }
 
-// sessionCtxKey is the context key used to attach session to requests.
+// sessionCtxKey is the context key used to attach the session to requests.
 type sessionCtxKey struct{}
 
-// Middleware returns a flow Middleware that loads session into request
-// context and exposes a Session for handlers to use.
+// Middleware returns a flow Middleware that loads the session into the request
+// context so handlers can call FromContext to retrieve it.
 func (sm *SessionManager) Middleware() Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -166,7 +268,8 @@ func FromContext(ctx context.Context) *Session {
 }
 
 // DefaultSessionManager constructs a manager with a random secret. It is
-// convenient for development but should be configured in production.
+// convenient for development but a stable secret must be configured in
+// production, otherwise sessions are invalidated on every restart.
 func DefaultSessionManager() *SessionManager {
 	s, _ := generateRandomSecret(32)
 	return NewSessionManager(s, "flow_session")

--- a/pkg/flow/session_encryption_test.go
+++ b/pkg/flow/session_encryption_test.go
@@ -1,0 +1,281 @@
+package flow
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSessionEncryption_PayloadIsOpaque verifies that the cookie value
+// written by Save() is not a readable base64-JSON blob. An attacker who
+// base64-decodes the first segment of the cookie value must NOT be able to
+// recover plaintext JSON.
+func TestSessionEncryption_PayloadIsOpaque(t *testing.T) {
+	sm := NewSessionManager([]byte("super-secret-key-32-bytes-long!!"), "sess")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s := &Session{values: map[string]interface{}{"user_id": 42, "role": "admin"}, sm: sm, w: rr, r: req}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	setCookie := rr.Header().Get("Set-Cookie")
+	if setCookie == "" {
+		t.Fatal("expected Set-Cookie header")
+	}
+
+	// Extract cookie value from "name=value; ..." header.
+	cookieVal := ""
+	for _, part := range strings.Split(setCookie, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "sess=") {
+			cookieVal = strings.TrimPrefix(part, "sess=")
+			break
+		}
+	}
+	if cookieVal == "" {
+		t.Fatalf("could not extract cookie value from: %q", setCookie)
+	}
+
+	// Split on "|" to get the ciphertext blob.
+	parts := strings.SplitN(cookieVal, "|", 2)
+	if len(parts) != 2 {
+		t.Fatalf("expected pipe-separated value, got: %q", cookieVal)
+	}
+
+	// Decode the first segment — must not be valid JSON.
+	blob, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if strings.Contains(string(blob), "user_id") || strings.Contains(string(blob), "admin") {
+		t.Errorf("cookie payload is NOT encrypted — plaintext JSON visible: %q", string(blob))
+	}
+}
+
+// TestSessionEncryption_RoundTrip verifies that a session written via Save()
+// can be read back via loadFromRequest with the same values.
+func TestSessionEncryption_RoundTrip(t *testing.T) {
+	sm := NewSessionManager([]byte("super-secret-key-32-bytes-long!!"), "sess")
+
+	// Write session.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s := &Session{
+		values: map[string]interface{}{
+			"user_id": float64(99), // JSON numbers unmarshal as float64
+			"email":   "alice@example.com",
+		},
+		sm: sm, w: rr, r: req,
+	}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Pluck the Set-Cookie header and replay it as a request cookie.
+	cookieHeader := rr.Header().Get("Set-Cookie")
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.Header.Set("Cookie", parseCookieValueFromHeader(t, cookieHeader, "sess"))
+
+	// Load it back.
+	vals, err := sm.loadFromRequest(req2)
+	if err != nil {
+		t.Fatalf("loadFromRequest: %v", err)
+	}
+	if vals["user_id"] != float64(99) {
+		t.Errorf("user_id: got %v, want 99", vals["user_id"])
+	}
+	if vals["email"] != "alice@example.com" {
+		t.Errorf("email: got %v, want alice@example.com", vals["email"])
+	}
+}
+
+// TestSessionEncryption_TamperedCiphertextRejected verifies that flipping a
+// byte in the ciphertext portion causes decryption to fail and returns an
+// empty session (not a panic or an error surfaced to the caller).
+func TestSessionEncryption_TamperedCiphertextRejected(t *testing.T) {
+	sm := NewSessionManager([]byte("super-secret-key-32-bytes-long!!"), "sess")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s := &Session{values: map[string]interface{}{"uid": "1234"}, sm: sm, w: rr, r: req}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	cookieHeader := rr.Header().Get("Set-Cookie")
+	rawVal := parseCookieRawValue(t, cookieHeader, "sess")
+
+	// Corrupt the last byte of the base64-encoded ciphertext blob (before |).
+	parts := strings.SplitN(rawVal, "|", 2)
+	blobBytes := []byte(parts[0])
+	blobBytes[len(blobBytes)-1] ^= 0xFF // flip bits
+	tampered := string(blobBytes) + "|" + parts[1]
+
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.Header.Set("Cookie", "sess="+tampered)
+
+	vals, err := sm.loadFromRequest(req2)
+	if err != nil {
+		t.Fatalf("loadFromRequest returned unexpected error: %v", err)
+	}
+	if len(vals) != 0 {
+		t.Errorf("expected empty session for tampered cookie, got: %v", vals)
+	}
+}
+
+// TestSessionEncryption_WrongSecretRejected verifies that a cookie encrypted
+// with one secret cannot be decrypted by a manager with a different secret.
+func TestSessionEncryption_WrongSecretRejected(t *testing.T) {
+	sm1 := NewSessionManager([]byte("secret-one-32-bytes-long-padding"), "sess")
+	sm2 := NewSessionManager([]byte("secret-two-32-bytes-long-padding"), "sess")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	s := &Session{values: map[string]interface{}{"uid": "abc"}, sm: sm1, w: rr, r: req}
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	cookieHeader := rr.Header().Get("Set-Cookie")
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.Header.Set("Cookie", parseCookieValueFromHeader(t, cookieHeader, "sess"))
+
+	vals, err := sm2.loadFromRequest(req2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vals) != 0 {
+		t.Errorf("expected empty session when using wrong secret, got: %v", vals)
+	}
+}
+
+// TestSessionEncryption_EachCookieIsUnique verifies that two Save() calls with
+// identical data produce different cookie values (due to random nonce).
+func TestSessionEncryption_EachCookieIsUnique(t *testing.T) {
+	sm := NewSessionManager([]byte("super-secret-key-32-bytes-long!!"), "sess")
+	data := map[string]interface{}{"x": "y"}
+
+	vals := make([]string, 3)
+	for i := range vals {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/", nil)
+		s := &Session{values: data, sm: sm, w: rr, r: req}
+		if err := s.Save(); err != nil {
+			t.Fatalf("Save %d: %v", i, err)
+		}
+		vals[i] = parseCookieRawValue(t, rr.Header().Get("Set-Cookie"), "sess")
+	}
+	if vals[0] == vals[1] || vals[1] == vals[2] {
+		t.Errorf("expected unique cookie values per Save(), got duplicates: %v", vals)
+	}
+}
+
+// TestSessionEncryption_NoCookieReturnsEmpty verifies that a request with no
+// session cookie returns an empty map without error.
+func TestSessionEncryption_NoCookieReturnsEmpty(t *testing.T) {
+	sm := NewSessionManager([]byte("super-secret-key-32-bytes-long!!"), "sess")
+	req := httptest.NewRequest("GET", "/", nil)
+	vals, err := sm.loadFromRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vals) != 0 {
+		t.Errorf("expected empty map, got: %v", vals)
+	}
+}
+
+// TestSessionEncryption_RedisAdapter_CookieIsSignedOnly verifies that the
+// RedisStoreAdapter (which stores data server-side) still writes a signed id
+// — not encrypted session data — in the cookie.
+func TestSessionEncryption_RedisAdapter_CookieIsSignedOnly(t *testing.T) {
+	rsa := NewRedisStoreAdapter([]byte("adapter-secret-32-bytes-long!!!!"), "sess", &RedisStore{})
+	// We only test the signing side (not actual Redis) — just verify the
+	// cookie format is id|sig (two hex-like parts joined by |).
+	sig := rsa.signID("test-session-id")
+	if sig == "" {
+		t.Fatal("signID returned empty string")
+	}
+	if len(sig) != 64 { // SHA-256 hex = 64 chars
+		t.Errorf("expected 64-char HMAC hex, got %d chars: %q", len(sig), sig)
+	}
+}
+
+// TestSessionEncryption_MiddlewareLoadsEncryptedSession is an end-to-end test
+// that exercises the Middleware → handler → FromContext path with an encrypted
+// cookie.
+func TestSessionEncryption_MiddlewareLoadsEncryptedSession(t *testing.T) {
+	sm := NewSessionManager([]byte("super-secret-key-32-bytes-long!!"), "sess")
+
+	// Phase 1: generate a cookie via a write handler.
+	writeReq := httptest.NewRequest("POST", "/login", nil)
+	writeRR := httptest.NewRecorder()
+	writeHandler := sm.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sess := FromContext(r.Context())
+		if sess == nil {
+			t.Error("FromContext returned nil inside middleware")
+			return
+		}
+		_ = sess.Set("logged_in", true)
+		_ = sess.Set("user", "bob")
+		w.WriteHeader(http.StatusOK)
+	}))
+	writeHandler.ServeHTTP(writeRR, writeReq)
+
+	// Phase 2: replay the cookie in a read request.
+	// Each sess.Set() calls Save() which appends a Set-Cookie header.
+	// Use the last one — it contains all keys written so far.
+	setCookieHeaders := writeRR.Header()["Set-Cookie"]
+	if len(setCookieHeaders) == 0 {
+		t.Fatal("no Set-Cookie headers written")
+	}
+	cookieHeader := setCookieHeaders[len(setCookieHeaders)-1]
+	readReq := httptest.NewRequest("GET", "/dashboard", nil)
+	readReq.Header.Set("Cookie", parseCookieValueFromHeader(t, cookieHeader, "sess"))
+	readRR := httptest.NewRecorder()
+
+	readHandler := sm.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sess := FromContext(r.Context())
+		if sess == nil {
+			t.Error("FromContext returned nil on read request")
+			return
+		}
+		v, ok := sess.Get("logged_in")
+		if !ok || v != true {
+			t.Errorf("expected logged_in=true, got %v (ok=%v)", v, ok)
+		}
+		user, ok := sess.Get("user")
+		if !ok || user != "bob" {
+			t.Errorf("expected user=bob, got %v (ok=%v)", user, ok)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	readHandler.ServeHTTP(readRR, readReq)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// parseCookieValueFromHeader extracts "name=value" from a Set-Cookie header
+// and returns it as a Cookie request header value.
+func parseCookieValueFromHeader(t *testing.T, header, name string) string {
+	t.Helper()
+	raw := parseCookieRawValue(t, header, name)
+	return name + "=" + raw
+}
+
+// parseCookieRawValue extracts just the value part of a named cookie from a
+// Set-Cookie header string.
+func parseCookieRawValue(t *testing.T, header, name string) string {
+	t.Helper()
+	for _, part := range strings.Split(header, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, name+"=") {
+			return strings.TrimPrefix(part, name+"=")
+		}
+	}
+	t.Fatalf("cookie %q not found in Set-Cookie header: %q", name, header)
+	return ""
+}


### PR DESCRIPTION
…rrNoCookie

Previously session data was only HMAC-signed (base64-encoded JSON), meaning any client could decode the cookie and read user IDs, roles, emails, or any other value stored in the session.

Changes in pkg/flow/session.go:
- encodeForCookie: JSON payload is now encrypted with AES-256-GCM before being base64url-encoded. Wire format: base64url(nonce||ciphertext)|hex(HMAC)
- loadFromRequest: verify HMAC first (authenticate-then-decrypt), then decrypt with AES-256-GCM. Tampered or foreign cookies return an empty session, not an error.
- NewSessionManager: derives two independent 32-byte sub-keys from the single caller-supplied secret via HMAC-SHA256(secret, info):
    - aeadKey: 'flow-session-enc'  (AES-256-GCM)
    - macKey:  'flow-session-mac'  (HMAC-SHA256 authentication) No external dependencies added; stdlib crypto only.
- Fix bare 'err == http.ErrNoCookie' -> 'errors.Is(err, http.ErrNoCookie)'
- Each Save() uses a fresh random 12-byte nonce so identical session data produces a different ciphertext on every write.
- Backward compat: old sign-only cookies are rejected (HMAC fails under new key derivation) and treated as absent; fresh sessions start.

Add pkg/flow/session_encryption_test.go with 8 tests:
  TestSessionEncryption_PayloadIsOpaque
  TestSessionEncryption_RoundTrip
  TestSessionEncryption_TamperedCiphertextRejected
  TestSessionEncryption_WrongSecretRejected
  TestSessionEncryption_EachCookieIsUnique
  TestSessionEncryption_NoCookieReturnsEmpty
  TestSessionEncryption_RedisAdapter_CookieIsSignedOnly
  TestSessionEncryption_MiddlewareLoadsEncryptedSession

<!--
Provide a short description of the change and reference any related issues.
Title format: feat(pkg): short description
-->

## Summary

Describe the change and why it's needed.

## Checklist
- [ ] Tests added/updated
- [ ] gofmt run (no changes required)
- [ ] go vet and staticcheck run locally
- [ ] Documentation updated (where applicable)

## Related
- Fixes: #

---
Please follow the repository CONTRIBUTING.md and add reviewer suggestions where appropriate.
