### PR TITLE
chore: add semver release policy to CONTRIBUTING.md; update CHANGELOG…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - Secure default middleware (`SecureHeaders`, `SessionCookieHardening`) and helper `WithSecureDefaults(*App)` to register conservative security headers and session cookie defaults. Added unit tests, an example (`examples/security_demo`) and docs (`docs/security.md`).
+- Middleware integration assertion tests covering Recovery, RequestID, Metrics, Timeout, stack ordering, and concurrency safety (`pkg/flow/middleware_integration_test.go`).
 
 ### Notes
 - Migration: enabling `WithSecureDefaults(app)` is opt-in. To avoid breaking existing setups, `SessionCookieHardening` can be enabled first to append conservative attributes on outgoing `Set-Cookie` headers; migrate session manager settings (call `ApplySecureCookieDefaults()`) once you confirm traffic and clients are compatible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,63 @@ If you prefer other tools, the important thing is to keep the output consistent 
 
 ---
 
+## Versioning & release policy
+
+Flow follows **[Semantic Versioning 2.0.0](https://semver.org/)** (`MAJOR.MINOR.PATCH`).
+
+| Version component | When to bump |
+|-------------------|--------------|
+| `MAJOR` | Breaking public API changes (removing/renaming exported symbols, changing middleware signatures, incompatible plugin interface changes). |
+| `MINOR` | New backwards-compatible features (new middleware, new `App` options, new helpers). |
+| `PATCH` | Backwards-compatible bug fixes, documentation, CI, dependency bumps that don't change the public API. |
+
+### Pre-1.0 policy
+
+While the module is on `v0.x.y`, minor bumps (`v0.N+1.0`) may contain breaking changes.
+Every breaking change **must** be documented in `CHANGELOG.md` under a `### Breaking` heading with a
+migration path.
+
+### How a release is made
+
+1. All intended changes are merged into `main`.
+2. `CHANGELOG.md` is updated: move items from `## [Unreleased]` into a new `## [vX.Y.Z] — YYYY-MM-DD` section.
+3. A PR titled `chore: release vX.Y.Z` is opened, reviewed, and merged.
+4. A maintainer creates a signed annotated tag on `main`:
+   ```sh
+   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+5. The CI release job builds cross-platform binaries and publishes the GitHub Release automatically.
+
+### Commit message conventions
+
+We follow the **Conventional Commits** spec. The prefix determines the changelog section:
+
+| Prefix | Changelog section | SemVer impact |
+|--------|-------------------|---------------|
+| `feat:` | Added | MINOR |
+| `fix:` | Fixed | PATCH |
+| `perf:` | Performance | PATCH |
+| `refactor:` | Refactored | PATCH |
+| `docs:` | Documentation | — |
+| `chore:` | — | — |
+| `test:` | — | — |
+| `BREAKING CHANGE:` footer | Breaking | MAJOR (or MINOR pre-1.0) |
+
+### Branch naming
+
+| Pattern | Purpose |
+|---------|---------|
+| `feat/<description>` | New feature |
+| `fix/<description>` | Bug fix |
+| `perf/<description>` | Performance improvement |
+| `refactor/<description>` | Code cleanup |
+| `test/<description>` | Tests only |
+| `docs/<description>` | Documentation only |
+| `chore/<description>` | Tooling, CI, deps |
+
+---
+
 ## Further notes
 
 - For changes that affect the public plugin API, please document the compatibility constraints and add a migration note in `CHANGELOG.md`.


### PR DESCRIPTION
… for v0.10.0

- Add Versioning & Release Policy section to CONTRIBUTING.md:
  - SemVer table (MAJOR/MINOR/PATCH rules)
  - Pre-1.0 policy (MINOR may break, must document migration)
  - Step-by-step release process (annotated tag + CI release job)
  - Conventional Commits table mapping prefix → changelog section → SemVer impact
  - Branch naming conventions table
- Update CHANGELOG.md:
  - Add middleware integration assertion tests to [Unreleased]
  - Confirm v0.10.0 release date as 2026-04-23

<!--
Provide a short description of the change and reference any related issues.
Title format: feat(pkg): short description
-->

## Summary

Describe the change and why it's needed.

## Checklist
- [ ] Tests added/updated
- [ ] gofmt run (no changes required)
- [ ] go vet and staticcheck run locally
- [ ] Documentation updated (where applicable)

## Related
- Fixes: #

---
Please follow the repository CONTRIBUTING.md and add reviewer suggestions where appropriate.
